### PR TITLE
Update packer image tag version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2
 library:
   build_image: &build_image
     docker:
-      - image: hashicorp/packer:1.4.5
+      - image: hashicorp/packer:1.7.10
     steps:
       - run:
           name: Determine which platform we use
@@ -22,7 +22,7 @@ library:
             fi
       - checkout
       - run: apk update
-      - run: apk add --no-progress python3 curl jq
+      - run: apk add --no-progress python3 curl jq py3-pip
       - run: pip3 install awscli pyyaml
       - run:
           name: install and configure gcloud sdk as needed


### PR DESCRIPTION
Hi, I forked this repository to our company Github Enterprise Server and try to build in our CircleCI Server v3.
I tried to build AWS AMI but packer failed to build and show these error.

```
Found 0 images for ubuntu-20.04_aws with SHA 478561fd89c5bc9a30082f36a80a753774b08d17 in **************

1644295402,,ui,error,Build 'amazon-ebs' errored: No valid credential sources found for AWS Builder. Please see https://www.packer.io/docs/builders/amazon.html#specifying-amazon-credentials for more information on providing credentials for the AWS Builder.
1644295402,,error-count,1
1644295402,,ui,error,\n==> Some builds didn't complete successfully and had errors:
1644295402,amazon-ebs,error,No valid credential sources found for AWS Builder. Please see https://www.packer.io/docs/builders/amazon.html#specifying-amazon-credentials for more information on providing credentials for the AWS Builder.
1644295402,,ui,error,--> amazon-ebs: No valid credential sources found for AWS Builder. Please see https://www.packer.io/docs/builders/amazon.html#specifying-amazon-credentials for more information on providing credentials for the AWS Builder.
1644295402,,ui,say,\n==> Builds finished but no artifacts were created.

Exited with code exit status 1
```

I set `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` to environment variables by CircleCI context, but packer didn't seem to use them.
I retried with the latest version of packer, it works. I don't know why that solved the problem, however hashicorp/packer:1.4.5 was releases two years ago, it should be updated to the newer version.

Furthermore, `hashicorp/packer:1.7.10` does not have `pip3`, so I added it.