### PR TITLE
Download maven from archive.apache.org

### DIFF
--- a/ubuntu-20.04/circleci-provision-scripts/java.sh
+++ b/ubuntu-20.04/circleci-provision-scripts/java.sh
@@ -36,7 +36,7 @@ function install_maven() {
     echo ">>> Installing Maven $MAVEN_VERSION"
 
     # Install Maven
-    curl -sSL -o /tmp/maven.tar.gz http://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz
+    curl -sSL -o /tmp/maven.tar.gz https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz
     tar -xz -C /usr/local -f /tmp/maven.tar.gz
     ln -sf /usr/local/apache-maven-${MAVEN_VERSION} /usr/local/apache-maven
     rm -rf /tmp/maven.tar.gz


### PR DESCRIPTION
I found java provisioning script raise error because maven 3.8.3 could not download now. (I tried to build image after pached #3 in my forked repository in our Github Enterprise Server)
Error log is here.

```
1644312434,,ui,error,==> amazon-ebs: + circleci-install maven 3.8.3
1644312434,,ui,message,    amazon-ebs: >>> Installing Maven 3.8.3
1644312435,,ui,error,==> amazon-ebs:
1644312435,,ui,error,==> amazon-ebs: gzip: stdin: not in gzip format
1644312435,,ui,error,==> amazon-ebs: tar: Child returned status 1
1644312435,,ui,error,==> amazon-ebs: tar: Error is not recoverable: exiting now
```

In fact, http://apache.osuosl.org/maven/maven-3/  has maven 3.8.4, but not 3.8.3.
One solution is update maven version to 3.8.4, but it will repeat same problem in the near future.

My suggestion is change download repository that have all released versions, and I found it from https://maven.apache.org/download.cgi.

> If you still want to use an old version you can find more information in the Maven Releases History and can download files from the [archives](https://archive.apache.org/dist/maven/maven-3/) for versions 3.0.4+ and legacy archives( for earlier releases.

