### PR TITLE
Fix util-linux install issue

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@circleci-public/on-prem

--- a/ubuntu-20.04/circleci-provision-scripts/misc.sh
+++ b/ubuntu-20.04/circleci-provision-scripts/misc.sh
@@ -40,7 +40,7 @@ function install_socat() {
 function install_nsenter() {
     apt-get install build-essential libncurses5-dev libslang2-dev gettext zlib1g-dev libselinux1-dev debhelper lsb-release pkg-config po-debconf autoconf automake autopoint libtool flex
     pushd /tmp
-    git clone git://git.kernel.org/pub/scm/utils/util-linux/util-linux.git util-linux
+    git clone --depth 1 --branch stable/v2.40 git://git.kernel.org/pub/scm/utils/util-linux/util-linux.git util-linux
     cd util-linux/
     ./autogen.sh
     ./configure --without-python --disable-all-programs --enable-nsenter

--- a/ubuntu-20.04/circleci-provision-scripts/misc.sh
+++ b/ubuntu-20.04/circleci-provision-scripts/misc.sh
@@ -38,7 +38,7 @@ function install_socat() {
 }
 
 function install_nsenter() {
-    apt-get install build-essential libncurses5-dev libslang2-dev gettext zlib1g-dev libselinux1-dev debhelper lsb-release pkg-config po-debconf autoconf automake autopoint libtool
+    apt-get install build-essential libncurses5-dev libslang2-dev gettext zlib1g-dev libselinux1-dev debhelper lsb-release pkg-config po-debconf autoconf automake autopoint libtool flex
     pushd /tmp
     git clone git://git.kernel.org/pub/scm/utils/util-linux/util-linux.git util-linux
     cd util-linux/

--- a/ubuntu-20.04/packer.yaml
+++ b/ubuntu-20.04/packer.yaml
@@ -59,7 +59,7 @@ builders:
   instance_type: "t3a.medium"
   ami_name: "ubuntu-2004-vm-circleci-classic-{{timestamp}}"
   ssh_username: "circleci"
-  ami_groups: "all"
+  # ami_groups: "all" Commenting out because of Error modify AMI attributes: OperationNotPermitted: You can’t publicly share this image because block public access for AMIs is enabled for this account.
   launch_block_device_mappings:
     - device_name: "/dev/sda1"
       volume_size: 10


### PR DESCRIPTION
Found out that this builder errors due to following issues:

- **Missing Dependency:** The build process requires `flex` to compile `util-linux`.
- **Incompatible `util-linux` Version:** The default `util-linux` branch repository may introduce build errors due to recent changes also the default branch is a development branch and we should reference the stable branch.


#### Error Logs Prior to Fix

- **Missing `flex` Dependency:** https://app.circleci.com/pipelines/github/nanophate/circleci-server-linux-image-builder/4/workflows/bdc58a15-8a31-4186-a5d1-18d89f6322df/jobs/8?invite=true#step-109-1383483_99
  ```
  ERROR: You must have flex installed to build the util-linux.
  ``` 

- **`util-linux` Build Failures:** https://app.circleci.com/pipelines/github/nanophate/circleci-server-linux-image-builder/9/workflows/9c1af78e-60e1-4a70-b16f-e1c978c00f8a/jobs/17?invite=true#step-109-1475139_147
  ```
  error: ‘SYS_pidfd_getfd’ undeclared (first use in this function)
  ...
  make: *** [Makefile:7442: all] Error 2
  ```

##### Changes Made
1. **Added `flex` to Installation Dependencies:**
   - Updated the `install_nsenter` function in `misc.sh` to include `flex` in the list of packages to be installed.

2. **Pinned `util-linux` to a Stable Version:**
   - Modified the Git clone command for `util-linux` in `misc.sh` to clone a specific stable branch (`stable/v2.40`) with a shallow clone (`--depth 1`). This ensures compatibility and avoids potential build issues from the latest, possibly unstable, commits.

#### **Testing**

- **Initial Build Verification:**
  - Created a separate branch with the proposed changes.
  - Performed an initial commit to trigger the build process.
  - https://app.circleci.com/pipelines/github/nanophate/circleci-server-linux-image-builder/26/workflows/40d3e723-66f9-473a-aa3b-53b699565399/jobs/53?invite=true#step-109-1459848_99
    <img width="1039" alt="Screenshot 2024-10-24 at 17 52 27" src="https://github.com/user-attachments/assets/206607c6-1daa-48c8-a6f8-7e6a3f784f9f">

- **Build Process:**
  - Confirmed that the CircleCI server Linux image builder no longer fails due to the missing `flex` dependency.
  - Verified that the build succeeds using the specified `util-linux` version (`stable/v2.40`).
  - https://app.circleci.com/pipelines/github/nanophate/circleci-server-linux-image-builder/28/workflows/84cf32d6-bdc1-45ef-840e-e72ecdf5c7bc/jobs/57?invite=true#step-109-1548483_128
    <img width="912" alt="Screenshot 2024-10-24 at 17 53 48" src="https://github.com/user-attachments/assets/4bd84a04-ab1f-4638-a5b4-3ff85f9687af">
    <img width="900" alt="Screenshot 2024-10-24 at 17 53 26" src="https://github.com/user-attachments/assets/8a31d1fd-e097-4c02-9cce-854e622607c6">

- **Functionality Check:**
  - Ensured that the resulting custom image is functional and compatible with Server 4.3 deployment.
    ![image](https://github.com/user-attachments/assets/b60dc759-e665-4a52-8c3a-509be7402f96)


